### PR TITLE
feat: add assert_grounded() and groundedness_score() to vectorlens.testing

### DIFF
--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,92 @@
+"""Tests for vectorlens.testing module."""
+from __future__ import annotations
+
+import pytest
+
+from vectorlens.testing import assert_grounded, groundedness_score
+from vectorlens.types import RetrievedChunk
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_chunk(chunk_id: str, text: str) -> RetrievedChunk:
+    """Build a minimal RetrievedChunk for testing."""
+    return RetrievedChunk(chunk_id=chunk_id, text=text, score=1.0)
+
+
+# ---------------------------------------------------------------------------
+# groundedness_score()
+# ---------------------------------------------------------------------------
+
+def test_groundedness_score_returns_float():
+    """groundedness_score() must return a float between 0.0 and 1.0."""
+    chunks = [_make_chunk("c1", "The sky is blue.")]
+    score = groundedness_score("The sky is blue.", chunks)
+    assert isinstance(score, float)
+    assert 0.0 <= score <= 1.0
+
+
+def test_groundedness_score_empty_response():
+    """Empty response should return 1.0 (nothing to hallucinate)."""
+    chunks = [_make_chunk("c1", "Some context.")]
+    score = groundedness_score("", chunks)
+    assert score == 1.0
+
+
+def test_groundedness_score_no_chunks():
+    """No chunks should return 0.0 (nothing to ground against)."""
+    score = groundedness_score("The sky is blue.", [])
+    assert score == 0.0
+
+
+# ---------------------------------------------------------------------------
+# assert_grounded()
+# ---------------------------------------------------------------------------
+
+def test_assert_grounded_passes_when_grounded():
+    """assert_grounded() must not raise when response is grounded."""
+    chunks = [_make_chunk("c1", "The sky is blue and the sun is bright.")]
+    # Should not raise
+    assert_grounded("The sky is blue.", chunks, min_score=0.5)
+
+
+def test_assert_grounded_raises_when_hallucinated():
+    """assert_grounded() must raise AssertionError when score is below min_score."""
+    chunks = [_make_chunk("c1", "Cats are fluffy animals.")]
+    with pytest.raises(AssertionError) as exc_info:
+        assert_grounded(
+            "Quantum physics governs the universe at subatomic scales.",
+            chunks,
+            min_score=0.99,
+        )
+    assert "Groundedness score" in str(exc_info.value)
+    assert "Hallucinated sentences" in str(exc_info.value)
+
+
+def test_assert_grounded_default_min_score():
+    """assert_grounded() default min_score must be 0.75."""
+    import inspect
+    from vectorlens.testing import assert_grounded
+    sig = inspect.signature(assert_grounded)
+    assert sig.parameters["min_score"].default == 0.75
+
+
+def test_assert_grounded_custom_message():
+    """assert_grounded() must include custom message in AssertionError."""
+    chunks = [_make_chunk("c1", "Cats are fluffy.")]
+    with pytest.raises(AssertionError) as exc_info:
+        assert_grounded(
+            "Quantum physics governs subatomic scales.",
+            chunks,
+            min_score=0.99,
+            message="Custom error message",
+        )
+    assert "Custom error message" in str(exc_info.value)
+
+
+def test_assert_grounded_empty_response():
+    """assert_grounded() must not raise for empty response."""
+    chunks = [_make_chunk("c1", "Some context.")]
+    assert_grounded("", chunks)

--- a/vectorlens/testing.py
+++ b/vectorlens/testing.py
@@ -1,0 +1,101 @@
+"""Testing utilities for VectorLens.
+
+Provides inline RAG quality assertions for use in pytest, Jupyter notebooks,
+or plain Python scripts — no server required.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from vectorlens.detection.hallucination import HallucinationDetector
+from vectorlens.types import RetrievedChunk
+
+
+def groundedness_score(
+    response_text: str,
+    chunks: list[RetrievedChunk],
+) -> float:
+    """
+    Compute the groundedness score of a response against retrieved chunks.
+
+    Parameters
+    ----------
+    response_text : str
+        The LLM response text to evaluate.
+
+    chunks : list[RetrievedChunk]
+        The retrieved chunks to compare against.
+
+    Returns
+    -------
+    float
+        A score between 0.0 and 1.0, where 1.0 means fully grounded.
+    """
+    if not response_text or not response_text.strip():
+        return 1.0
+
+    detector = HallucinationDetector()
+    tokens = detector.detect(response_text, chunks)
+
+    if not tokens:
+        return 1.0
+
+    grounded = sum(1 for t in tokens if not t.is_hallucinated)
+    return grounded / len(tokens)
+
+
+def assert_grounded(
+    response_text: str,
+    chunks: list[RetrievedChunk],
+    min_score: float = 0.75,
+    message: Optional[str] = None,
+) -> None:
+    """
+    Assert that a RAG response is grounded in the retrieved chunks.
+
+    Parameters
+    ----------
+    response_text : str
+        The LLM response text to evaluate.
+
+    chunks : list[RetrievedChunk]
+        The retrieved chunks to compare against.
+
+    min_score : float, optional, default=0.75
+        Minimum groundedness score (0.0 to 1.0) required to pass.
+
+    message : str, optional
+        Custom message to include in the AssertionError.
+
+    Raises
+    ------
+    AssertionError
+        If the groundedness score is below min_score, with a diff
+        showing which sentences were hallucinated.
+    """
+    detector = HallucinationDetector()
+    tokens = detector.detect(response_text, chunks)
+
+    if not tokens:
+        return
+
+    hallucinated = [t for t in tokens if t.is_hallucinated]
+    grounded_count = len(tokens) - len(hallucinated)
+    score = grounded_count / len(tokens)
+
+    if score < min_score:
+        diff_lines = [
+            f"Groundedness score {score:.2f} is below minimum {min_score:.2f}",
+            f"  Grounded sentences : {grounded_count}/{len(tokens)}",
+            f"  Hallucinated sentences: {len(hallucinated)}/{len(tokens)}",
+            "",
+            "Hallucinated sentences:",
+        ]
+        for t in hallucinated:
+            diff_lines.append(f"  - [{t.position}] {t.text!r}")
+
+        diff = "\n".join(diff_lines)
+        if message:
+            diff = f"{message}\n{diff}"
+
+        raise AssertionError(diff)


### PR DESCRIPTION
Closes #13

## Summary
Added inline RAG quality assertion utilities to `vectorlens/testing.py` — works with no server running.

## Changes Made
- `vectorlens/testing.py`: Two functions:
  - `assert_grounded(response_text, chunks, min_score=0.75, message=None)` — raises `AssertionError` with readable diff showing hallucinated sentences if score is below threshold
  - `groundedness_score(response_text, chunks)` — returns float 0.0–1.0 for non-asserting use
- `tests/test_testing.py`: 6 tests covering both functions